### PR TITLE
Add support for v1

### DIFF
--- a/.github/workflows/github_action.yml
+++ b/.github/workflows/github_action.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
 
     container:
-      image: crystallang/crystal:1.0.0
+      image: crystallang/crystal
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/github_action.yml
+++ b/.github/workflows/github_action.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
 
     container:
-      image: crystallang/crystal
+      image: crystallang/crystal:0.36.1
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/github_action.yml
+++ b/.github/workflows/github_action.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
 
     container:
-      image: crystallang/crystal:0.36.1
+      image: crystallang/crystal:1.0.0
 
     steps:
     - uses: actions/checkout@v2

--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,6 @@
 name: shivneri
 version: 0.17.0
+crystal: ">= 0.36.0 - 1.0"
 
 authors:
   - Ujjwal Gupta <ujjwalkumargupta44@gmail.com>
@@ -14,7 +15,5 @@ dependencies:
 # development_dependencies:
 #   webmock:
 #     github: manastech/webmock.cr
-
-crystal: 0.36.0
 
 license: APACHE 2.0

--- a/tests/general/e2e/controller/cookie_controller_spec.cr
+++ b/tests/general/e2e/controller/cookie_controller_spec.cr
@@ -30,7 +30,7 @@ describe "CookieController" do
     body["max_age"].should eq 5000
     body["http_only"].should eq false
     body["path"].should eq "/"
-    cookies = HTTP::Cookies.from_headers(response.headers)
+    cookies = HTTP::Cookies.from_server_headers(response.headers)
     cookies[cookie_name]?.as(HTTP::Cookie).value.should eq cookie_value_obj[:cookie_value]
     cookies[cookie_name]?.as(HTTP::Cookie).path.should eq "/"
     cookies[cookie_name]?.as(HTTP::Cookie).secure.should eq false
@@ -65,7 +65,7 @@ describe "CookieController" do
     body["max_age"].should eq 3600
     body["http_only"].should eq false
     body["path"].should eq "/"
-    cookies = HTTP::Cookies.from_headers(response.headers)
+    cookies = HTTP::Cookies.from_server_headers(response.headers)
     cookies[cookie_name]?.as(HTTP::Cookie).value.should eq cookie_value_obj[:cookie_value]
     cookies[cookie_name]?.as(HTTP::Cookie).path.should eq "/"
     cookies[cookie_name]?.as(HTTP::Cookie).secure.should eq false
@@ -91,7 +91,7 @@ describe "CookieController" do
     })
     response.status_code.should eq 200
     cookie_string = response.headers["Set-Cookie"]
-    cookies = HTTP::Cookies.from_headers(response.headers)
+    cookies = HTTP::Cookies.from_server_headers(response.headers)
     cookies[cookie_name]?.as(HTTP::Cookie).path.should eq "/"
     cookies[cookie_name]?.as(HTTP::Cookie).secure.should eq false
     cookies[cookie_name]?.as(HTTP::Cookie).http_only.should eq false

--- a/tests/general/e2e/controller/cookie_controller_spec.cr
+++ b/tests/general/e2e/controller/cookie_controller_spec.cr
@@ -30,11 +30,11 @@ describe "CookieController" do
     body["max_age"].should eq 5000
     body["http_only"].should eq false
     body["path"].should eq "/"
-    cookies = HTTP::Cookies.from_server_headers(response.headers)
-    cookies[cookie_name]?.as(HTTP::Cookie).value.should eq cookie_value_obj[:cookie_value]
-    cookies[cookie_name]?.as(HTTP::Cookie).path.should eq "/"
-    cookies[cookie_name]?.as(HTTP::Cookie).secure.should eq false
-    cookies[cookie_name]?.as(HTTP::Cookie).http_only.should eq false
+    cookies = response.cookies
+    cookie = cookies[cookie_name]
+    cookie.value.should eq cookie_value_obj[:cookie_value]
+    cookie.secure.should eq false
+    cookie.http_only.should eq false
     cookie_string = response.headers["Set-Cookie"]
   end
 
@@ -65,11 +65,10 @@ describe "CookieController" do
     body["max_age"].should eq 3600
     body["http_only"].should eq false
     body["path"].should eq "/"
-    cookies = HTTP::Cookies.from_server_headers(response.headers)
-    cookies[cookie_name]?.as(HTTP::Cookie).value.should eq cookie_value_obj[:cookie_value]
-    cookies[cookie_name]?.as(HTTP::Cookie).path.should eq "/"
-    cookies[cookie_name]?.as(HTTP::Cookie).secure.should eq false
-    cookies[cookie_name]?.as(HTTP::Cookie).http_only.should eq false
+    cookie = response.cookies[cookie_name]
+    cookie.value.should eq cookie_value_obj[:cookie_value]
+    cookie.secure.should eq false
+    cookie.http_only.should eq false
     cookie_string = response.headers["Set-Cookie"]
   end
 
@@ -91,11 +90,9 @@ describe "CookieController" do
     })
     response.status_code.should eq 200
     cookie_string = response.headers["Set-Cookie"]
-    cookies = HTTP::Cookies.from_server_headers(response.headers)
-    cookies[cookie_name]?.as(HTTP::Cookie).path.should eq "/"
-    cookies[cookie_name]?.as(HTTP::Cookie).secure.should eq false
-    cookies[cookie_name]?.as(HTTP::Cookie).http_only.should eq false
-    # cookies[cookie_name]?.as(HTTP::Cookie).expires.should eq ""
+    cookie = response.cookies[cookie_name]
+    cookie.secure.should eq false
+    cookie.http_only.should eq false
     status = (cookie_string.includes? "Expires=1900-01-01 00:00:00 UTC; Max-Age=-1;")
     status.should eq true
     response.body.should eq "deleted"

--- a/tests/server/shard.lock
+++ b/tests/server/shard.lock
@@ -5,6 +5,6 @@ shards:
     version: 0.7.0
 
   shivneri:
-    git: https://github.com/ujjwalguptaofficial/shivneri.git
+    path: ../..
     version: 0.14.1
 

--- a/tests/server/shard.yml
+++ b/tests/server/shard.yml
@@ -14,4 +14,4 @@ license: MIT
 
 dependencies:
   shivneri:
-    github: ujjwalguptaofficial/shivneri
+    path: ../..


### PR DESCRIPTION
Hi @ujjwalguptaofficial,

This `PR` adds support for `crystal` **v1.0**

It :

+ [x] Allow compilation on `crystal` **v1.0** in `shard.yml`
+ [x] Refactors cookie spec (`path` is not **/** anymore) @see https://github.com/crystal-lang/crystal/pull/10491
+ [x] Upgrade version used in `server` **spec** (it was previously `0.14.1`)

I have, however, 2 feedbacks :
+ `lock` files are **NOT** required on this repository, imho
+ specifying `crystal: 0.36.0` in `shard.yml` in `spec` **folder** are not useful

Regards,